### PR TITLE
remove governor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1417,12 +1417,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
-
-[[package]]
 name = "futures-util"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1483,23 +1477,6 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "governor"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c390a940a5d157878dd057c78680a33ce3415bcd05b4799509ea44210914b4d5"
-dependencies = [
- "cfg-if",
- "dashmap",
- "futures",
- "futures-timer",
- "no-std-compat",
- "nonzero_ext",
- "parking_lot 0.12.1",
- "rand 0.8.5",
- "smallvec",
-]
 
 [[package]]
 name = "h2"
@@ -2465,12 +2442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "no-std-compat"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93853da6d84c2e3c7d730d6473e8817692dd89be387eb01b94d7f108ecb5b8c"
-
-[[package]]
 name = "nodrop"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2507,12 +2478,6 @@ dependencies = [
  "memchr 2.5.0",
  "minimal-lexical",
 ]
-
-[[package]]
-name = "nonzero_ext"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
 
 [[package]]
 name = "notify"
@@ -4803,7 +4768,6 @@ dependencies = [
  "futures",
  "futures-util",
  "glob",
- "governor",
  "headers",
  "http",
  "humanize",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -248,7 +248,7 @@ transforms-metricalize = ["async-stream"]
 transforms-route = ["condition"]
 transforms-sample = ["seahash"]
 transforms-substr = []
-transforms-throttle = ["governor"]
+transforms-throttle = []
 
 # sinks
 sinks = [
@@ -426,7 +426,6 @@ evmap = { version = "10.0.2", default-features = false, optional = true }
 exitcode = { version = "1.1.2" }
 flate2 = { version = "1.0.25", optional = true }
 glob = { version = "0.3.1" }
-governor = { version = "0.5.1", default-features = false, optional = true, features = ["dashmap", "jitter", "std"] }
 indexmap = { version = "1.9.2", default-features = false, features = ["serde"] }
 inventory = { version = "0.3.3" }
 k8s-openapi = { version = "0.17.0", default-features = false, optional = true, features = ["api", "v1_20"] }

--- a/src/sources/demo_logs.rs
+++ b/src/sources/demo_logs.rs
@@ -1,18 +1,14 @@
-use std::num::NonZeroU32;
-use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use configurable::configurable_component;
 use event::{fields, tags, LogRecord};
 use framework::config::{DataType, Output, SourceConfig, SourceContext};
 use framework::Source;
-use futures_util::StreamExt;
-use governor::state::StreamRateLimitExt;
-use governor::{Quota, RateLimiter};
 use log_schema::log_schema;
 
-const fn default_rate() -> u32 {
-    1
+const fn default_interval() -> Duration {
+    Duration::from_secs(1)
 }
 
 const fn default_count() -> usize {
@@ -22,13 +18,13 @@ const fn default_count() -> usize {
 #[configurable_component(source, name = "demo_logs")]
 #[derive(Debug)]
 struct DemoLogsConfig {
-    /// How many logs to produce
+    /// How many logs to produce.
     #[serde(default = "default_count")]
     count: usize,
 
-    /// Rate of produce
-    #[serde(default = "default_rate")]
-    rate: u32,
+    /// The amount of time, to pause between each batch of output lines.
+    #[serde(default = "default_interval", with = "humanize::duration::serde")]
+    interval: Duration,
 
     /// Log content to produce
     #[configurable(required = true)]
@@ -41,32 +37,30 @@ impl SourceConfig for DemoLogsConfig {
     async fn build(&self, cx: SourceContext) -> framework::Result<Source> {
         let message = self.log.clone();
         let mut output = cx.output;
-        let rate = self.rate;
         let count = self.count;
+        let mut ticker = tokio::time::interval(self.interval);
+        let mut shutdown = cx.shutdown;
 
         Ok(Box::pin(async move {
-            let limiter = Arc::new(RateLimiter::direct(Quota::per_second(
-                NonZeroU32::new(rate).unwrap(),
-            )));
-            let mut stream = futures::stream::repeat_with(move || {
-                LogRecord::new(
+            for _n in 0..count {
+                tokio::select! {
+                    _ = &mut shutdown => break,
+                    _ = ticker.tick() => {}
+                }
+
+                let log = LogRecord::new(
                     tags!(
                         "source_type" => "demo_logs",
                     ),
                     fields!(
                         log_schema().message_key() => message.as_str()
                     ),
-                )
-            })
-            .take(count)
-            .take_until(cx.shutdown)
-            .ratelimit_stream(&limiter)
-            .ready_chunks(1024);
+                );
 
-            while let Some(logs) = stream.next().await {
-                if let Err(err) = output.send(logs).await {
-                    error!(message = "Error sending logs", ?err);
-                    return Err(());
+                if let Err(err) = output.send(log).await {
+                    error!(message = "send demo log to output failed", ?err);
+
+                    break;
                 }
             }
 

--- a/src/transforms/throttle/gcra.rs
+++ b/src/transforms/throttle/gcra.rs
@@ -1,0 +1,515 @@
+use std::fmt::{Debug, Display, Formatter};
+use std::time::{Duration, Instant};
+
+#[derive(Clone, Copy, Debug)]
+/// Defines the configuration for a GCRA rate limit.
+pub struct Quota {
+    /// Amount of resources that are allowed in a given period.
+    pub resource_limit: u32,
+
+    /// The length of which to allow access to the resource.
+    pub period: Duration,
+
+    /// Incremental duration cost of a single resource check
+    pub emission_interval: Duration,
+}
+
+impl Quota {
+    pub fn new(resource_limit: u32, period: Duration) -> Self {
+        let emission_interval = period / resource_limit;
+        Self {
+            resource_limit,
+            period,
+            emission_interval,
+        }
+    }
+
+    /// Given a `cost`, calculates the increment interval.
+    #[inline]
+    pub fn increment_interval(&self, cost: u32) -> Duration {
+        self.emission_interval * cost
+    }
+}
+
+#[derive(Debug)]
+pub enum GcraError {
+    /// Cost of the increment exceeds the rate limit and will never succeed
+    DeniedIndefinitely(u32),
+    /// Limited request until after the [Instant]
+    DeniedUntil(Instant),
+}
+
+impl Display for GcraError {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GcraError::DeniedIndefinitely(cost) => {
+                write!(
+                    fmt,
+                    "cost of the increment {} exceeds the rate limit and will never succeed",
+                    cost
+                )
+            }
+            GcraError::DeniedUntil(next) => write!(fmt, "denied until {:?}", next),
+        }
+    }
+}
+
+/// Holds the minmum amount of state necessary to implement a GRCA leaky buckets.
+/// Refer to: [understanding GCRA](https://blog.ian.stapletoncordas.co/2018/12/understanding-generic-cell-rate-limiting.html)
+#[derive(Default, Debug)]
+pub struct GcraState {
+    /// GCRA's Theoretical Arrival Time (**TAT**)
+    /// An unset value signals a new state
+    pub tat: Option<Instant>,
+}
+
+impl GcraState {
+    /// Check if we are allowed to proceed. If so updated our internal state and return true.
+    ///
+    /// Simply passes the current Instant to [`check_and_modify_at()`]
+    #[inline]
+    pub fn check_and_modify(&mut self, rate_limit: &Quota, cost: u32) -> Result<(), GcraError> {
+        let arrived_at = Instant::now();
+        self.check_and_modify_at(rate_limit, arrived_at, cost)
+    }
+
+    /// Check if we are allowed to proceed at the given arrival time.
+    /// If so updated our internal state and return true.
+    /// Explaination of GCRA can be found [here](https://blog.ian.stapletoncordas.co/2018/12/understanding-generic-cell-rate-limiting.html)
+    ///
+    /// # Returns
+    /// If denied, will return an [Result::Err] where the value is the next allowed timestamp.
+    pub fn check_and_modify_at(
+        &mut self,
+        rate_limit: &Quota,
+        arrived_at: Instant,
+        cost: u32,
+    ) -> Result<(), GcraError> {
+        let increment_interval = rate_limit.increment_interval(cost);
+
+        let compute_tat = |new_tat: Instant| {
+            if increment_interval > rate_limit.period {
+                return Err(GcraError::DeniedIndefinitely(cost));
+            }
+
+            Ok(new_tat + increment_interval)
+        };
+
+        let tat = match self.tat {
+            Some(tat) => tat,
+            None => {
+                // First ever request. Allow passage and update self.
+                self.tat = Some(compute_tat(arrived_at)?);
+                return Ok(());
+            }
+        };
+
+        // We had a previous request
+        if tat < arrived_at {
+            // prev request was really old
+            let new_tat = std::cmp::max(tat, arrived_at);
+            self.tat = Some(compute_tat(new_tat)?);
+            Ok(())
+        } else {
+            // prev request was recent and there's a possibility that we've reached the limit
+            let delay_variation_tolerance = rate_limit.period;
+            let new_tat = compute_tat(tat)?;
+
+            let next_allowed_at = new_tat - delay_variation_tolerance;
+            if next_allowed_at <= arrived_at {
+                self.tat = Some(new_tat);
+                Ok(())
+            } else {
+                // Denied, must wait until next_allowed_at
+                Err(GcraError::DeniedUntil(next_allowed_at))
+            }
+        }
+    }
+
+    /// Reverts rate_limit by cost, and updated our internal state.
+    ///
+    /// Simply passes the current Instant to [`revert_at()`]
+    #[inline]
+    #[allow(dead_code)]
+    pub fn revert(&mut self, rate_limit: &Quota, cost: u32) -> Result<(), GcraError> {
+        let arrived_at = Instant::now();
+        self.revert_at(rate_limit, arrived_at, cost)
+    }
+
+    /// Reverts rate_limit by cost, and updated our internal state.
+    ///
+    /// This is a hack that substracts the incremental cost from the TAT.
+    pub fn revert_at(
+        &mut self,
+        rate_limit: &Quota,
+        arrived_at: Instant,
+        cost: u32,
+    ) -> Result<(), GcraError> {
+        let increment_interval = rate_limit.increment_interval(cost);
+
+        let compute_revert_tat = |new_tat: Instant| new_tat - increment_interval;
+
+        let tat = match self.tat {
+            Some(tat) => tat,
+            None => {
+                // First ever request. Nothing to do.
+                return Ok(());
+            }
+        };
+
+        // We had a previous request
+        if tat < arrived_at {
+            // Reset state: prev request was really old
+            self.tat = None;
+        } else {
+            // prev request was recent
+            self.tat = Some(compute_revert_tat(tat));
+        }
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub fn remaining_resources(&self, rate_limit: &Quota, now: Instant) -> u32 {
+        if rate_limit.period.is_zero() {
+            return 0;
+        }
+
+        let time_to_tat = match self.tat.and_then(|tat| tat.checked_duration_since(now)) {
+            Some(duration_until) => duration_until.as_secs_f32(),
+            None => return rate_limit.resource_limit,
+        };
+
+        // Logically this makes more sense as:
+        //   consumed_resources = time_to_tat * (resource_limit/period)
+        // but we run it this way because of Duration's arithmetic functions
+        let consumed_resources =
+            (time_to_tat * rate_limit.resource_limit as f32) / rate_limit.period.as_secs_f32();
+        rate_limit.resource_limit - consumed_resources.ceil() as u32
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+
+    #[test]
+    fn rate_limit_emission_interval() {
+        let rate_limit = Quota::new(10, Duration::from_secs(20));
+        assert_eq!(Duration::from_secs(2), rate_limit.emission_interval)
+    }
+
+    #[test]
+    fn test_rate_limit_unused_counts() {
+        let base_tat = Instant::now();
+        let rate_limit = Quota::new(10, Duration::from_secs(1));
+
+        assert_eq!(
+            4,
+            GcraState {
+                tat: Some(base_tat + Duration::from_millis(550))
+            }
+            .remaining_resources(&rate_limit, base_tat),
+            "Remaining count should ceiled"
+        );
+        assert_eq!(
+            0,
+            GcraState {
+                tat: Some(base_tat + Duration::from_millis(950))
+            }
+            .remaining_resources(&rate_limit, base_tat),
+            "Remaining count should ceiled, thus preventing any additional requests"
+        );
+
+        assert_eq!(
+            9,
+            GcraState {
+                tat: Some(base_tat + Duration::from_millis(100))
+            }
+            .remaining_resources(&rate_limit, base_tat),
+            "Remaining count is based on max_period timeout"
+        );
+    }
+
+    #[test]
+    fn gcra_basics() {
+        let mut gcra = GcraState::default();
+        let rate_limit = Quota::new(1, Duration::from_secs(1));
+
+        let first_req_ts = Instant::now();
+
+        assert!(
+            gcra.check_and_modify(&rate_limit, 1).is_ok(),
+            "request #1 should pass"
+        );
+        let after_first_tat = gcra.tat;
+        assert!(
+            after_first_tat.is_some(),
+            "state should be modified and have a TAT in the future"
+        );
+
+        let next_allowed_ts = match gcra.check_and_modify(&rate_limit, 1) {
+            Err(GcraError::DeniedUntil(next_allowed_at)) => next_allowed_at,
+            _ => panic!("request #2 should be denied temporarily"),
+        };
+        assert!(
+            next_allowed_ts >= first_req_ts + Duration::from_secs(1),
+            "we should only be allowed after the burst period"
+        );
+        assert_eq!(after_first_tat, gcra.tat, "State should be unchanged.")
+    }
+
+    #[test]
+    fn gcra_limited() {
+        const LIMIT: u32 = 5;
+        let mut gcra = GcraState::default();
+        let rate_limit = Quota::new(LIMIT, Duration::from_secs(1));
+
+        let req_ts = Instant::now();
+        for i in 0..LIMIT {
+            assert!(
+                gcra.check_and_modify_at(&rate_limit, req_ts, 1).is_ok(),
+                "request #{} should pass",
+                i + 1
+            );
+        }
+
+        assert_eq!(
+            Some(req_ts + rate_limit.period),
+            gcra.tat,
+            "state should be modified and have a TAT for the full period",
+        );
+
+        // Trigger another event
+        let denied_result = gcra.check_and_modify_at(&rate_limit, req_ts, 1);
+
+        assert_eq!(
+            Some(req_ts + rate_limit.period),
+            gcra.tat,
+            "state should not have changed when at limit",
+        );
+
+        assert!(
+            matches!(
+                denied_result,
+                Err(GcraError::DeniedUntil (
+                    next_allowed_at
+                )) if next_allowed_at == req_ts + rate_limit.emission_interval
+            ),
+            "next request should be denied",
+        );
+    }
+
+    #[test]
+    fn gcra_revert_new() {
+        const LIMIT: u32 = 5;
+        let mut gcra = GcraState::default();
+        let rate_limit = Quota::new(LIMIT, Duration::from_secs(1));
+
+        let req_ts = Instant::now();
+        // Revert before any calls
+        assert!(
+            gcra.revert_at(&rate_limit, req_ts, 1).is_ok(),
+            "revert should have released resources"
+        );
+        assert_eq!(None, gcra.tat, "state should not have changed at all",);
+    }
+
+    #[test]
+    fn gcra_revert_existing() {
+        const LIMIT: u32 = 5;
+        let mut gcra = GcraState::default();
+        let rate_limit = Quota::new(LIMIT, Duration::from_secs(1));
+
+        let req_ts = Instant::now();
+        assert!(
+            gcra.check_and_modify_at(&rate_limit, req_ts, 5).is_ok(),
+            "use up all resources",
+        );
+
+        assert_eq!(
+            Some(req_ts + rate_limit.period),
+            gcra.tat,
+            "state should be modified and have a TAT for the full period",
+        );
+
+        // Revert
+        assert!(
+            gcra.revert_at(&rate_limit, req_ts, 1).is_ok(),
+            "revert should have released resources"
+        );
+        assert_eq!(
+            Some(req_ts + rate_limit.period - rate_limit.increment_interval(1)),
+            gcra.tat,
+            "state should not have changed when at limit",
+        );
+
+        // Confirm revert re-enables
+        assert!(
+            gcra.check_and_modify_at(&rate_limit, req_ts, 1).is_ok(),
+            "additional resources should have been freed",
+        );
+    }
+
+    #[test]
+    fn gcra_revert_existing_ancient() {
+        const LIMIT: u32 = 5;
+        let mut gcra = GcraState::default();
+        let rate_limit = Quota::new(LIMIT, Duration::from_secs(1));
+
+        let past_req_ts = Instant::now() - Duration::from_secs(100);
+        assert!(
+            gcra.check_and_modify_at(&rate_limit, past_req_ts, 5)
+                .is_ok(),
+            "use up all resources, but in distant past",
+        );
+        assert!(
+            matches!(gcra.tat, Some(want) if want == past_req_ts + rate_limit.period),
+            "state should be modified and have a TAT for the past",
+        );
+
+        // Revert using current time
+        let req_ts = Instant::now();
+        assert!(
+            gcra.revert_at(&rate_limit, req_ts, 1).is_ok(),
+            "revert should have released resources"
+        );
+        assert_eq!(
+            None, gcra.tat,
+            "state should have reset since it was so old",
+        );
+
+        // Confirm revert had 0 effect
+        assert!(
+            gcra.check_and_modify_at(&rate_limit, req_ts, 1).is_ok(),
+            "additional resources should have been freed",
+        );
+        assert!(
+            matches!(gcra.tat, Some(want) if want == req_ts + rate_limit.increment_interval(1)),
+            "new TAT state should have been moved forward according to cost like normal"
+        );
+    }
+
+    #[test]
+    fn gcra_leaky() {
+        // const INCREMENT_INTERVAL: u64 = 500;
+        const INCREMENT_INTERVAL: Duration = Duration::from_millis(500);
+
+        let mut gcra = GcraState::default();
+        let rate_limit = Quota::new(10, 10 * INCREMENT_INTERVAL);
+        assert_eq!(INCREMENT_INTERVAL, rate_limit.emission_interval);
+
+        let arrived_at = Instant::now();
+        assert!(
+            gcra.check_and_modify_at(&rate_limit, arrived_at, 1).is_ok(),
+            "request #1 should pass"
+        );
+        assert_eq!(
+            gcra.tat,
+            Some(arrived_at + INCREMENT_INTERVAL),
+            "new TAT state should have been moved forward according to cost"
+        );
+
+        assert!(
+            gcra.check_and_modify(&rate_limit, 9).is_ok(),
+            "request #2 should consume all remaining resources and pass"
+        );
+        assert!(
+            matches!(gcra.check_and_modify(&rate_limit, 1), Err(_allowed_at)),
+            "request #3 should fail since all resources consumed"
+        );
+
+        let current_tat = gcra.tat.expect("should have a tat state after use");
+        assert!(current_tat > Instant::now(), "tat in the future");
+
+        assert!(
+            matches!(
+                // manually force time check that we know will fail
+                gcra.check_and_modify_at(
+                    &rate_limit,
+                    current_tat - rate_limit.period - Duration::from_millis(1),
+                    1
+                ),
+                Err(_allowed_at)
+            ),
+            "request #4 before leak period should fail. INCREMENT_INTERVAL has not passed yet."
+        );
+
+        assert!(
+            matches!(
+                gcra.check_and_modify_at(&rate_limit, current_tat - rate_limit.period, 1),
+                Err(_allowed_at)
+            ),
+            "request #5 after leak period should pass. INCREMENT_INTERVAL has passed"
+        );
+    }
+
+    #[test]
+    fn gcra_cost_indefinitely_denied() {
+        let mut gcra = GcraState::default();
+        let rate_limit = Quota::new(5, Duration::from_secs(1));
+
+        assert!(
+            gcra.check_and_modify(&rate_limit, 1).is_ok(),
+            "request #1 should pass"
+        );
+
+        let over_limit_cost = rate_limit.resource_limit + 1;
+        match gcra.check_and_modify(&rate_limit, over_limit_cost) {
+            Err(GcraError::DeniedIndefinitely(cost)) => {
+                assert_eq!(over_limit_cost, cost);
+            }
+            e => panic!("request #2 would never succeed {:?}", e),
+        };
+    }
+
+    #[test]
+    fn gcra_cost_temporarily_denied() {
+        let mut gcra = GcraState::default();
+        let rate_limit = Quota::new(5, Duration::from_secs(1));
+
+        let first_req_ts = Instant::now();
+        assert!(
+            gcra.check_and_modify(&rate_limit, 1).is_ok(),
+            "request #1 should pass"
+        );
+
+        let after_first_tat = gcra.tat;
+        assert!(
+            after_first_tat.is_some(),
+            "state should be modified and have a TAT in the future"
+        );
+
+        let next_allowed_ts = match gcra.check_and_modify(&rate_limit, rate_limit.resource_limit) {
+            Err(GcraError::DeniedUntil(next_allowed_at)) => next_allowed_at,
+            _ => panic!("request #2 is only temporarily denied"),
+        };
+
+        assert!(
+            next_allowed_ts >= first_req_ts + rate_limit.increment_interval(1),
+            "we should only be allowed after the burst period {:?} >= {:?}",
+            next_allowed_ts,
+            first_req_ts + rate_limit.period
+        );
+        assert_eq!(after_first_tat, gcra.tat, "State should be unchanged.")
+    }
+
+    #[test]
+    fn gcra_refreshed_after_period() {
+        let past_time = Instant::now() - Duration::from_millis(1001);
+        let mut gcra = GcraState {
+            tat: Some(past_time),
+        };
+        let rate_limit = Quota::new(1, Duration::from_secs(1));
+        assert!(
+            gcra.check_and_modify(&rate_limit, 1).is_ok(),
+            "request #1 should pass"
+        );
+
+        assert!(
+            matches!(gcra.check_and_modify(&rate_limit, 1), Err(_allowed_at)),
+            "request #2 should fail"
+        );
+    }
+}

--- a/src/transforms/throttle/rate_limiter.rs
+++ b/src/transforms/throttle/rate_limiter.rs
@@ -1,0 +1,110 @@
+use std::collections::BTreeMap;
+use std::time::Instant;
+
+use super::gcra::{GcraState, Quota};
+
+pub struct RateLimiter {
+    quota: Quota,
+    state: GcraState,
+}
+
+impl RateLimiter {
+    pub fn new(quota: Quota) -> Self {
+        Self {
+            quota,
+            state: Default::default(),
+        }
+    }
+
+    pub fn check(&mut self) -> bool {
+        self.state.check_and_modify(&self.quota, 1).is_ok()
+    }
+}
+
+/// KeyedRateLimiter is not thread-safe, but in our case, that is what we
+/// want.
+pub struct KeyedRateLimiter {
+    quota: Quota,
+    states: BTreeMap<String, GcraState>,
+}
+
+impl KeyedRateLimiter {
+    pub const fn new(quota: Quota) -> Self {
+        Self {
+            quota,
+            states: BTreeMap::new(),
+        }
+    }
+}
+
+impl KeyedRateLimiter {
+    pub fn check(&mut self, key: &str) -> bool {
+        let state = match self.states.get_mut(key) {
+            Some(state) => state,
+            None => {
+                let state = GcraState::default();
+                self.states.insert(key.to_owned(), state);
+                self.states
+                    .get_mut(key)
+                    .expect("state should be insert already")
+            }
+        };
+
+        state.check_and_modify(&self.quota, 1).is_ok()
+    }
+
+    pub fn retain_recent(&mut self) {
+        let now = Instant::now();
+
+        self.states.retain(|_key, state| match state.tat {
+            Some(tat) => tat > now,
+            None => false,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::thread::sleep;
+    use std::time::Duration;
+
+    use super::*;
+
+    const LIMIT: u32 = 3u32;
+    const WINDOW: Duration = Duration::from_secs(1);
+
+    #[test]
+    fn rl() {
+        let quota = Quota::new(LIMIT, WINDOW);
+        let mut limiter = RateLimiter::new(quota);
+        for _i in 0..LIMIT {
+            assert!(limiter.check());
+        }
+        assert!(!limiter.check());
+        sleep(WINDOW);
+        assert!(limiter.check())
+    }
+
+    #[test]
+    fn keyed() {
+        let key_1 = "foo";
+        let key_2 = "bar";
+        let quota = Quota::new(LIMIT, WINDOW);
+
+        let mut rl = KeyedRateLimiter::new(quota);
+        for _i in 0..LIMIT {
+            assert!(rl.check(key_1));
+            assert!(rl.check(key_2));
+        }
+
+        assert!(!rl.check(key_1));
+        assert!(!rl.check(key_2));
+
+        sleep(2 * WINDOW);
+        assert!(rl.check(key_1));
+
+        rl.retain_recent();
+        assert!(rl.states.contains_key(key_1));
+        assert!(!rl.states.contains_key(key_2));
+    }
+}


### PR DESCRIPTION
We don't need a fancy rate limiter, even "thread safe" is not what we need, cause all calls is inside a loop.

Removing this dep will help us to reduce binary size.