### PR TITLE
disable elasticsearch integration tests

### DIFF
--- a/src/sinks/elasticsearch/mod.rs
+++ b/src/sinks/elasticsearch/mod.rs
@@ -6,9 +6,9 @@ mod retry;
 mod service;
 mod sink;
 
-#[cfg(test)]
-#[cfg(feature = "integration-tests-elasticsearch")]
-mod integration_tests;
+// #[cfg(all(test, feature = "integration-tests-elasticsearch"))]
+// mod integration_tests;
+
 #[cfg(test)]
 mod tests;
 


### PR DESCRIPTION
This will be re-enabled in the future