### PR TITLE
sources/node: reduce tokio io calls

### DIFF
--- a/src/sources/node/arp.rs
+++ b/src/sources/node/arp.rs
@@ -8,11 +8,11 @@ use event::{tags, tags::Key, Metric};
 use super::Error;
 
 pub async fn gather(proc_path: PathBuf) -> Result<Vec<Metric>, Error> {
-    let content = std::fs::read_to_string(proc_path.join("net/arp"))?;
-    let mut devices = HashMap::new();
+    let data = std::fs::read_to_string(proc_path.join("net/arp"))?;
 
+    let mut devices = HashMap::new();
     // the first line is title, so we don't need it
-    for line in content.lines().skip(1) {
+    for line in data.lines().skip(1) {
         let dev = line.split_ascii_whitespace().nth(5).expect("must exists");
 
         devices

--- a/src/sources/node/bcache.rs
+++ b/src/sources/node/bcache.rs
@@ -394,10 +394,10 @@ struct WritebackRateDebugStats {
 }
 
 fn read_writeback_rate_debug(path: PathBuf) -> Result<WritebackRateDebugStats, Error> {
-    let content = std::fs::read_to_string(path)?;
-    let mut stats = WritebackRateDebugStats::default();
+    let data = std::fs::read_to_string(path)?;
 
-    for line in content.lines() {
+    let mut stats = WritebackRateDebugStats::default();
+    for line in data.lines() {
         if let Some(value) = line.strip_prefix("rate:") {
             let value = value.trim().strip_suffix("/sec").unwrap_or(value);
             let value = parse_bytes(value)
@@ -475,10 +475,10 @@ struct PriorityStats {
 // Sectors per Q:	64
 // Quantiles:	[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 20946 20946 20946 20946 20946 20946 20946 20946 20946 20946 20946 20946 20946 20946 20946 20946]
 fn read_priority_stats(path: PathBuf) -> Result<PriorityStats, Error> {
-    let content = read_to_string(path)?;
-    let mut stats = PriorityStats::default();
+    let data = std::fs::read_to_string(path)?;
 
-    for line in content.lines() {
+    let mut stats = PriorityStats::default();
+    for line in data.lines() {
         if let Some(value) = line.strip_prefix("Unused:") {
             if let Some(text) = value.trim().strip_suffix('%') {
                 stats.unused_percent = text.parse()?;

--- a/src/sources/node/cpu.rs
+++ b/src/sources/node/cpu.rs
@@ -5,7 +5,6 @@ use std::path::PathBuf;
 use event::{tags, tags::Key, Metric};
 use framework::config::{default_true, serde_regex};
 use serde::{Deserialize, Serialize};
-use tokio::io::AsyncBufReadExt;
 
 use super::Error;
 
@@ -121,12 +120,10 @@ struct CPUStat {
 }
 
 async fn get_cpu_stat(proc_path: PathBuf) -> Result<Vec<CPUStat>, Error> {
-    let file = tokio::fs::File::open(proc_path.join("stat")).await?;
-    let reader = tokio::io::BufReader::new(file);
-    let mut lines = reader.lines();
-    let mut stats = Vec::new();
+    let data = std::fs::read_to_string(proc_path.join("stat"))?;
 
-    while let Some(line) = lines.next_line().await? {
+    let mut stats = Vec::new();
+    for line in data.lines() {
         if !line.starts_with("cpu") {
             continue;
         }

--- a/src/sources/node/diskstats.rs
+++ b/src/sources/node/diskstats.rs
@@ -35,7 +35,6 @@ pub fn default_ignored() -> regex::Regex {
 }
 
 pub async fn gather(conf: Config, root: PathBuf) -> Result<Vec<Metric>, Error> {
-    let mut metrics = Vec::new();
     let data = std::fs::read_to_string(root.join("diskstats"))?;
 
     // https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats
@@ -79,6 +78,7 @@ pub async fn gather(conf: Config, root: PathBuf) -> Result<Vec<Metric>, Error> {
     //     ==  =====================================
     //
     //     For more details refer to Documentation/admin-guide/iostats.rst
+    let mut metrics = Vec::new();
     for line in data.lines() {
         // the content looks like this
         // 259       0 nvme0n1 366 0 23480 41 3 0 0 0 0 41 41 0 0 0 0
@@ -325,13 +325,10 @@ fn udev_device_properties(major: &str, minor: &str) -> Result<HashMap<String, St
     let mut properties = HashMap::new();
     for line in data.lines() {
         // we're only interested in device properties
-        match line.strip_prefix("E:") {
-            Some(value) => {
-                if let Some((key, value)) = value.split_once("=") {
-                    properties.insert(key.to_string(), value.to_string());
-                }
+        if let Some(value) = line.strip_prefix("E:") {
+            if let Some((key, value)) = value.split_once("=") {
+                properties.insert(key.to_string(), value.to_string());
             }
-            None => continue,
         }
     }
 

--- a/src/sources/node/meminfo.rs
+++ b/src/sources/node/meminfo.rs
@@ -29,12 +29,10 @@ pub async fn gather(root: PathBuf) -> Result<Vec<Metric>, Error> {
 }
 
 async fn get_mem_info(root: PathBuf) -> Result<HashMap<String, f64>, std::io::Error> {
+    let data = std::fs::read_to_string(root.join("meminfo"))?;
+
     let mut infos = HashMap::new();
-
-    let content = std::fs::read_to_string(root.join("meminfo"))?;
-    let lines = content.lines();
-
-    for line in lines {
+    for line in data.lines() {
         let parts = line.split_ascii_whitespace().collect::<Vec<_>>();
 
         let mut fv = parts[1]

--- a/src/sources/node/netdev.rs
+++ b/src/sources/node/netdev.rs
@@ -6,7 +6,7 @@ use framework::config::serde_regex;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 
-use super::{read_to_string, Error};
+use super::Error;
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
@@ -146,10 +146,10 @@ pub async fn gather(conf: Config, proc_path: PathBuf) -> Result<Vec<Metric>, Err
 
 impl Config {
     async fn get_net_dev_stats(&self, proc_path: PathBuf) -> Result<Vec<DeviceStatus>, Error> {
-        let content = read_to_string(proc_path.join("net/dev"))?;
-        let lines = content.lines();
+        let data = std::fs::read_to_string(proc_path.join("net/dev"))?;
+
         let mut stats = Vec::new();
-        for line in lines.skip(2) {
+        for line in data.lines().skip(2) {
             let stat = DeviceStatus::from_str(line)?;
             stats.push(stat);
         }

--- a/src/sources/node/nfsd.rs
+++ b/src/sources/node/nfsd.rs
@@ -2,7 +2,6 @@ use std::convert::{TryFrom, TryInto};
 use std::path::{Path, PathBuf};
 
 use event::{tags, Metric};
-use tokio::io::AsyncBufReadExt;
 
 use super::nfs::{Network, V2Stats, V3Stats};
 use super::Error;
@@ -294,12 +293,10 @@ struct ServerRPCStats {
 }
 
 async fn server_rpc_stats<P: AsRef<Path>>(path: P) -> Result<ServerRPCStats, Error> {
-    let f = tokio::fs::File::open(path).await?;
-    let reader = tokio::io::BufReader::new(f);
-    let mut lines = reader.lines();
+    let data = std::fs::read_to_string(path)?;
 
     let mut stats = ServerRPCStats::default();
-    while let Some(line) = lines.next_line().await? {
+    for line in data.lines() {
         let parts = line.trim().split_ascii_whitespace().collect::<Vec<_>>();
 
         if parts.len() < 2 {

--- a/src/sources/node/os_release.rs
+++ b/src/sources/node/os_release.rs
@@ -4,7 +4,7 @@ use std::sync::LazyLock;
 use chrono::NaiveDate;
 use event::{tags, Metric};
 
-use super::{read_to_string, Error};
+use super::Error;
 
 const ETC_OS_RELEASE: &str = "/etc/os-release";
 const USR_LIB_OS_RELEASE: &str = "/usr/lib/os-release";
@@ -77,10 +77,10 @@ fn release_infos() -> Result<BTreeMap<String, String>, Error> {
 }
 
 fn parse_os_release(path: &str) -> Result<BTreeMap<String, String>, Error> {
-    let content = read_to_string(path)?;
-    let mut envs = BTreeMap::new();
+    let data = std::fs::read_to_string(path)?;
 
-    for line in content.lines() {
+    let mut envs = BTreeMap::new();
+    for line in data.lines() {
         if let Some((key, value)) = line.split_once('=') {
             let value = value.trim_matches('"').to_string();
             envs.insert(key.to_string(), value);

--- a/src/sources/node/pressure.rs
+++ b/src/sources/node/pressure.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 
 use event::Metric;
 
-use super::{read_to_string, Error};
+use super::Error;
 
 pub async fn gather(proc_path: PathBuf) -> Result<Vec<Metric>, Error> {
     let cpu = psi_stats(proc_path.join("pressure/cpu")).await?;
@@ -93,13 +93,13 @@ struct PSIStats {
 }
 
 async fn psi_stats(path: PathBuf) -> Result<PSIStats, Error> {
-    let content = read_to_string(path)?;
+    let data = std::fs::read_to_string(path)?;
     let mut stats = PSIStats {
         some: None,
         full: None,
     };
 
-    for line in content.lines() {
+    for line in data.lines() {
         let stat = parse_psi_stat(line)?;
 
         if line.starts_with("some") {

--- a/src/sources/node/schedstat.rs
+++ b/src/sources/node/schedstat.rs
@@ -3,7 +3,6 @@
 use std::path::PathBuf;
 
 use event::{tags, Metric};
-use tokio::io::AsyncBufReadExt;
 
 use super::Error;
 
@@ -49,12 +48,10 @@ pub async fn gather(proc_path: PathBuf) -> Result<Vec<Metric>, Error> {
 }
 
 async fn schedstat(proc_path: PathBuf) -> Result<Vec<Schedstat>, Error> {
-    let f = tokio::fs::File::open(proc_path.join("schedstat")).await?;
-    let r = tokio::io::BufReader::new(f);
-    let mut lines = r.lines();
+    let data = std::fs::read_to_string(proc_path.join("schedstat"))?;
 
     let mut stats = Vec::new();
-    while let Some(line) = lines.next_line().await? {
+    for line in data.lines() {
         if !line.starts_with("cpu") {
             continue;
         }

--- a/src/sources/node/selinux.rs
+++ b/src/sources/node/selinux.rs
@@ -49,10 +49,9 @@ fn get_enabled(proc_path: PathBuf) -> Result<bool, Error> {
 }
 
 fn default_enforce_mode() -> Result<bool, Error> {
-    let content = read_to_string("/etc/selinux/config")?;
-    for line in content.lines() {
-        let line = line.trim();
+    let data = std::fs::read_to_string("/etc/selinux/config")?;
 
+    for line in data.lines() {
         if let Some(value) = line.strip_prefix("SELINUX=") {
             return if value == "enforcing" {
                 Ok(true)

--- a/src/sources/node/softirqs.rs
+++ b/src/sources/node/softirqs.rs
@@ -1,4 +1,3 @@
-use std::io::BufRead;
 use std::num::ParseIntError;
 use std::path::PathBuf;
 
@@ -33,11 +32,9 @@ impl Softirqs {
                 .collect::<Result<Vec<u64>, ParseIntError>>()
         }
 
-        let file = std::fs::File::open(path)?;
-        let mut lines = std::io::BufReader::new(file).lines();
-
+        let data = std::fs::read_to_string(path)?;
         let mut stat = Self::default();
-        while let Some(Ok(line)) = lines.next() {
+        for line in data.lines() {
             let parts = line.split_ascii_whitespace().collect::<Vec<_>>();
 
             // require at least one cpu

--- a/src/sources/node/stat.rs
+++ b/src/sources/node/stat.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use event::Metric;
 
-use super::{read_to_string, Error};
+use super::Error;
 
 pub async fn gather(proc_path: PathBuf) -> Result<Vec<Metric>, Error> {
     let stat = read_stat(proc_path).await?;
@@ -50,10 +50,10 @@ struct Stat {
 }
 
 async fn read_stat(proc_path: PathBuf) -> Result<Stat, Error> {
-    let content = read_to_string(proc_path.join("stat"))?;
+    let data = std::fs::read_to_string(proc_path.join("stat"))?;
 
     let mut stat = Stat::default();
-    for line in content.lines() {
+    for line in data.lines() {
         if line.starts_with("ctxt ") {
             stat.ctxt = line.strip_prefix("ctxt ").unwrap().parse().unwrap_or(0u64);
             continue;

--- a/src/sources/node/vmstat.rs
+++ b/src/sources/node/vmstat.rs
@@ -6,7 +6,6 @@ use event::Metric;
 use framework::config::serde_regex;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use tokio::io::AsyncBufReadExt;
 
 use super::Error;
 
@@ -31,12 +30,11 @@ impl Default for Config {
 }
 
 pub async fn gather(conf: Config, proc_path: PathBuf) -> Result<Vec<Metric>, Error> {
-    let file = tokio::fs::File::open(proc_path.join("vmstat")).await?;
-    let mut lines = tokio::io::BufReader::new(file).lines();
-    let mut metrics = Vec::new();
+    let data = std::fs::read_to_string(proc_path.join("vmstat"))?;
 
-    while let Some(line) = lines.next_line().await? {
-        if !conf.fields.is_match(&line) {
+    let mut metrics = Vec::new();
+    for line in data.lines() {
+        if !conf.fields.is_match(line) {
             continue;
         }
 

--- a/src/sources/node/xfs.rs
+++ b/src/sources/node/xfs.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 use event::{tags, tags::Key, Metric};
 
-use super::{read_to_string, Error};
+use super::Error;
 
 pub async fn gather(sys_path: PathBuf) -> Result<Vec<Metric>, Error> {
     let stats = xfs_sys_stats(sys_path).await?;
@@ -430,10 +430,10 @@ async fn xfs_sys_stats(sys_path: PathBuf) -> Result<Vec<Stats>, Error> {
 }
 
 async fn parse_stat(path: PathBuf) -> Result<Stats, Error> {
-    let content = read_to_string(path)?;
+    let data = std::fs::read_to_string(path)?;
 
     let mut stat = Stats::default();
-    for line in content.lines() {
+    for line in data.lines() {
         let parts = line.split_ascii_whitespace().collect::<Vec<_>>();
 
         // Expact at least a string label and a single integer value, ex:


### PR DESCRIPTION
Now, tokio io calls is less, so blocking threads is less, collector duration is lower too. But the memory usage is not changed.

Collect duration.
![image](https://github.com/user-attachments/assets/9ccdc54a-fe91-4657-be32-46f3f08a3225)

CPU
![image](https://github.com/user-attachments/assets/6c6c929b-d7fb-42e3-8cfc-36b039408bd3)
