### PR TITLE
sources/node: optimize read_to_string, less allocation, less syscall

### DIFF
--- a/src/sources/node/btrfs.rs
+++ b/src/sources/node/btrfs.rs
@@ -181,7 +181,7 @@ fn get_allocation_stats(typ: &str, uuid: &str, stats: AllocationStats) -> Vec<Me
 
     // Add all layout statistics
     for (mode, usage) in stats.layouts {
-        metrics.extend_from_slice(&[
+        metrics.extend([
             Metric::gauge_with_tags(
                 "node_btrfs_used_bytes",
                 "Amount of used space by a layout/data type",
@@ -356,10 +356,10 @@ fn read_commit_stats(path: PathBuf) -> Result<CommitStats, Error> {
 }
 
 async fn list_files(path: impl AsRef<Path>) -> Result<Vec<String>, Error> {
-    let mut dirs = std::fs::read_dir(path)?;
-    let mut files = vec![];
+    let dirs = std::fs::read_dir(path)?;
 
-    while let Some(Ok(entry)) = dirs.next() {
+    let mut files = vec![];
+    for entry in dirs.flatten() {
         let name = entry.file_name().into_string().unwrap();
         files.push(name);
     }
@@ -368,11 +368,10 @@ async fn list_files(path: impl AsRef<Path>) -> Result<Vec<String>, Error> {
 }
 
 async fn read_device_info(path: &Path) -> Result<BTreeMap<String, Device>, Error> {
-    let path = path.join("devices");
-    let mut dirs = std::fs::read_dir(path)?;
+    let dirs = std::fs::read_dir(path.join("devices"))?;
 
     let mut devices = BTreeMap::new();
-    while let Some(Ok(entry)) = dirs.next() {
+    for entry in dirs.flatten() {
         let name = entry.file_name().to_string_lossy().to_string();
         let path = entry.path().join("size");
         let size: u64 = read_into(path).unwrap_or(0);
@@ -421,10 +420,10 @@ async fn read_layouts(
     root: PathBuf,
     devices: usize,
 ) -> Result<BTreeMap<String, LayoutUsage>, Error> {
-    let mut dirs = std::fs::read_dir(root)?;
+    let dirs = std::fs::read_dir(root)?;
 
     let mut layouts = BTreeMap::new();
-    while let Some(Ok(entry)) = dirs.next() {
+    for entry in dirs.flatten() {
         let path = entry.path();
         if !path.is_dir() {
             continue;

--- a/src/sources/node/cpu.rs
+++ b/src/sources/node/cpu.rs
@@ -63,10 +63,10 @@ macro_rules! state_metric {
 
 pub async fn gather(conf: Config, proc_path: PathBuf) -> Result<Vec<Metric>, Error> {
     let stats = get_cpu_stat(proc_path).await?;
-    let mut metrics = Vec::with_capacity(stats.len() * 10);
 
+    let mut metrics = Vec::with_capacity(stats.len() * 10);
     for (cpu, stat) in stats.iter().enumerate() {
-        metrics.extend_from_slice(&[
+        metrics.extend([
             state_metric!(cpu, "user", stat.user),
             state_metric!(cpu, "nice", stat.nice),
             state_metric!(cpu, "system", stat.system),
@@ -80,25 +80,26 @@ pub async fn gather(conf: Config, proc_path: PathBuf) -> Result<Vec<Metric>, Err
         // Guest CPU is also accounted for in cpuStat.User and cpuStat.Nice,
         // expose these as separate metrics.
         if conf.guest {
-            metrics.push(Metric::sum_with_tags(
-                "node_cpu_guest_seconds_total",
-                "Seconds the CPUs spent in guests (VMs) for each mode.",
-                stat.guest,
-                tags!(
-                    Key::from_static("cpu") => cpu as i64,
-                    Key::from_static("mode") => "user",
+            metrics.extend([
+                Metric::sum_with_tags(
+                    "node_cpu_guest_seconds_total",
+                    "Seconds the CPUs spent in guests (VMs) for each mode.",
+                    stat.guest,
+                    tags!(
+                        Key::from_static("cpu") => cpu as i64,
+                        Key::from_static("mode") => "user",
+                    ),
                 ),
-            ));
-
-            metrics.push(Metric::sum_with_tags(
-                "node_cpu_guest_seconds_total",
-                "Seconds the CPUs spent in guests (VMs) for each mode.",
-                stat.guest_nice,
-                tags!(
-                    Key::from_static("cpu") => cpu as i64,
-                    Key::from_static("mode") => "nice"
+                Metric::sum_with_tags(
+                    "node_cpu_guest_seconds_total",
+                    "Seconds the CPUs spent in guests (VMs) for each mode.",
+                    stat.guest_nice,
+                    tags!(
+                        Key::from_static("cpu") => cpu as i64,
+                        Key::from_static("mode") => "nice"
+                    ),
                 ),
-            ));
+            ]);
         }
     }
 

--- a/src/sources/node/cpufreq.rs
+++ b/src/sources/node/cpufreq.rs
@@ -119,8 +119,8 @@ async fn get_cpu_freq_stat(sys_path: PathBuf) -> Result<Vec<Stat>, Error> {
         "{}/devices/system/cpu/cpu[0-9]*",
         sys_path.to_string_lossy()
     ))?;
-    let mut stats = Vec::new();
 
+    let mut stats = Vec::new();
     for path in cpus.flatten() {
         let stat = parse_cpu_freq_cpu_info(path).await?;
         stats.push(stat)

--- a/src/sources/node/diskstats.rs
+++ b/src/sources/node/diskstats.rs
@@ -34,8 +34,8 @@ pub fn default_ignored() -> regex::Regex {
     regex::Regex::new(r#"^(z?ram|loop|fd|(h|s|v|xv)d[a-z]|nvme\d+n\d+p)\d+$"#).unwrap()
 }
 
-pub async fn gather(conf: Config, root: PathBuf) -> Result<Vec<Metric>, Error> {
-    let data = std::fs::read_to_string(root.join("diskstats"))?;
+pub async fn gather(conf: Config, proc_path: PathBuf) -> Result<Vec<Metric>, Error> {
+    let data = std::fs::read_to_string(proc_path.join("diskstats"))?;
 
     // https://www.kernel.org/doc/Documentation/ABI/testing/procfs-diskstats
     //

--- a/src/sources/node/dmi.rs
+++ b/src/sources/node/dmi.rs
@@ -1,4 +1,3 @@
-use std::fs::read_dir;
 use std::io::ErrorKind;
 use std::path::PathBuf;
 
@@ -34,52 +33,309 @@ struct DesktopManagementInterface {
 
 impl DesktopManagementInterface {
     fn parse(root: PathBuf) -> Result<Self, Error> {
-        let mut dirs = read_dir(root)?;
-        let mut dmi = DesktopManagementInterface::default();
+        let dirs = std::fs::read_dir(root)?;
 
-        while let Some(Ok(entry)) = dirs.next() {
+        let mut dmi = DesktopManagementInterface::default();
+        for entry in dirs.flatten() {
             if !entry.metadata()?.is_file() {
                 continue;
             }
 
-            let name = entry.file_name();
-            if name == "modalias" || name == "uevent" {
-                continue;
-            }
+            match entry.file_name().to_string_lossy().as_ref() {
+                "bios_date" => {
+                    dmi.bios_date = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
 
-            let value = match read_to_string(entry.path()) {
-                Ok(value) => value,
-                Err(err) => {
-                    if err.kind() == ErrorKind::PermissionDenied {
-                        continue;
+                                return Err(err.into());
+                            }
+                        }
                     }
-
-                    return Err(err.into());
                 }
-            };
+                "bios_release" => {
+                    dmi.bios_release = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
 
-            match name.to_string_lossy().as_ref() {
-                "bios_date" => dmi.bios_date = Some(value),
-                "bios_release" => dmi.bios_release = Some(value),
-                "bios_vendor" => dmi.bios_vendor = Some(value),
-                "bios_version" => dmi.bios_version = Some(value),
-                "board_asset_tag" => dmi.board_asset_tag = Some(value),
-                "board_name" => dmi.board_name = Some(value),
-                "board_serial" => dmi.board_serial = Some(value),
-                "board_vendor" => dmi.board_vendor = Some(value),
-                "board_version" => dmi.board_version = Some(value),
-                "chassis_asset_tag" => dmi.chassis_asset_tag = Some(value),
-                "chassis_serial" => dmi.chassis_serial = Some(value),
-                "chassis_type" => dmi.chassis_type = Some(value),
-                "chassis_vendor" => dmi.chassis_vendor = Some(value),
-                "chassis_version" => dmi.chassis_version = Some(value),
-                "product_family" => dmi.product_family = Some(value),
-                "product_name" => dmi.product_name = Some(value),
-                "product_serial" => dmi.product_serial = Some(value),
-                "product_sku" => dmi.product_sku = Some(value),
-                "product_uuid" => dmi.product_uuid = Some(value),
-                "product_version" => dmi.product_version = Some(value),
-                "system_vendor" => dmi.system_vendor = Some(value),
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
+                "bios_vendor" => {
+                    dmi.bios_vendor = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
+
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
+                "bios_version" => {
+                    dmi.bios_version = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
+
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
+                "board_asset_tag" => {
+                    dmi.board_asset_tag = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
+
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
+                "board_name" => {
+                    dmi.board_name = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
+
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
+                "board_serial" => {
+                    dmi.board_serial = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
+
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
+                "board_vendor" => {
+                    dmi.board_vendor = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
+
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
+                "board_version" => {
+                    dmi.board_version = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
+
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
+                "chassis_asset_tag" => {
+                    dmi.chassis_asset_tag = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
+
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
+                "chassis_serial" => {
+                    dmi.chassis_serial = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
+
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
+                "chassis_type" => {
+                    dmi.chassis_type = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
+
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
+                "chassis_vendor" => {
+                    dmi.chassis_vendor = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
+
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
+                "chassis_version" => {
+                    dmi.chassis_version = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
+
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
+                "product_family" => {
+                    dmi.product_family = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
+
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
+                "product_name" => {
+                    dmi.product_name = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
+
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
+                "product_serial" => {
+                    dmi.product_serial = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
+
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
+                "product_sku" => {
+                    dmi.product_sku = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
+
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
+                "product_uuid" => {
+                    dmi.product_uuid = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
+
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
+                "product_version" => {
+                    dmi.product_version = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
+
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
+                "system_vendor" => {
+                    dmi.system_vendor = {
+                        match read_to_string(entry.path()) {
+                            Ok(value) => Some(value),
+                            Err(err) => {
+                                if err.kind() == ErrorKind::PermissionDenied {
+                                    continue;
+                                }
+
+                                return Err(err.into());
+                            }
+                        }
+                    }
+                }
                 _ => continue,
             }
         }

--- a/src/sources/node/drm.rs
+++ b/src/sources/node/drm.rs
@@ -23,7 +23,7 @@ pub async fn gather(sys_path: PathBuf) -> Result<Vec<Metric>, Error> {
         let vendor = "amd".to_string();
         let tags = tags!("card" => card.clone());
 
-        metrics.extend_from_slice(&[
+        metrics.extend([
             Metric::gauge_with_tags(
                 "node_drm_card_info",
                 "Card information",

--- a/src/sources/node/ipvs.rs
+++ b/src/sources/node/ipvs.rs
@@ -1,5 +1,5 @@
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use event::tags::Tags;
 use event::Metric;
@@ -33,7 +33,7 @@ fn default_labels() -> Vec<String> {
 }
 
 pub async fn gather(conf: Config, proc_path: PathBuf) -> Result<Vec<Metric>, Error> {
-    let stats = parse_ipvs_stats(proc_path.clone()).await?;
+    let stats = parse_ipvs_stats(&proc_path).await?;
 
     let mut metrics = vec![
         Metric::sum(
@@ -110,7 +110,7 @@ pub async fn gather(conf: Config, proc_path: PathBuf) -> Result<Vec<Metric>, Err
             tags.insert(key, kv[i].clone());
         }
 
-        metrics.extend_from_slice(&[
+        metrics.extend([
             Metric::gauge_with_tags(
                 "node_ipvs_backend_connections_active",
                 "The current active connections by local and remote address.",
@@ -153,7 +153,7 @@ struct IPVSStats {
     outgoing_bytes: u64,
 }
 
-async fn parse_ipvs_stats(root: PathBuf) -> Result<IPVSStats, Error> {
+async fn parse_ipvs_stats(root: &Path) -> Result<IPVSStats, Error> {
     let data = std::fs::read_to_string(root.join("net/ip_vs_stat"))?;
     let lines = data.lines().collect::<Vec<_>>();
     if lines.len() < 4 {

--- a/src/sources/node/mdadm.rs
+++ b/src/sources/node/mdadm.rs
@@ -6,7 +6,7 @@ use std::sync::LazyLock;
 use event::{tags, tags::Key, Metric};
 use regex::Regex;
 
-use super::{read_to_string, Error};
+use super::Error;
 
 /// MDStat holds info parsed from /proc/mdstat
 #[derive(Debug, PartialEq)]
@@ -52,7 +52,7 @@ struct MDStat {
 }
 
 async fn parse_mdstat<P: AsRef<Path>>(path: P) -> Result<Vec<MDStat>, Error> {
-    let content = read_to_string(path)?;
+    let content = std::fs::read_to_string(path)?;
     let lines = content.split('\n').collect::<Vec<_>>();
 
     let mut stats = vec![];
@@ -272,7 +272,7 @@ fn state_metric_value(key: &str, state: &str) -> f64 {
 pub async fn gather(proc_path: PathBuf) -> Result<Vec<Metric>, Error> {
     let stats = parse_mdstat(proc_path.join("mdstat")).await?;
 
-    let mut metrics = vec![];
+    let mut metrics = Vec::with_capacity(stats.len() * 11);
     for stat in stats {
         let device = stat.name;
         let state = stat.activity_state;

--- a/src/sources/node/meminfo.rs
+++ b/src/sources/node/meminfo.rs
@@ -6,21 +6,22 @@ use event::Metric;
 
 use super::Error;
 
-pub async fn gather(root: PathBuf) -> Result<Vec<Metric>, Error> {
-    let infos = get_mem_info(root).await?;
-    let mut metrics = Vec::new();
-    for (k, v) in infos {
-        if k.ends_with("_total") {
+pub async fn gather(proc_path: PathBuf) -> Result<Vec<Metric>, Error> {
+    let infos = get_mem_info(proc_path).await?;
+
+    let mut metrics = Vec::with_capacity(infos.len());
+    for (key, value) in infos {
+        if key.ends_with("_total") {
             metrics.push(Metric::sum(
-                format!("node_memory_{}", k),
-                format!("Memory information field {}", k),
-                v,
+                format!("node_memory_{}", key),
+                format!("Memory information field {}", key),
+                value,
             ));
         } else {
             metrics.push(Metric::gauge(
-                format!("node_memory_{}", k),
-                format!("Memory information field {}", k),
-                v,
+                format!("node_memory_{}", key),
+                format!("Memory information field {}", key),
+                value,
             ));
         }
     }

--- a/src/sources/node/netclass.rs
+++ b/src/sources/node/netclass.rs
@@ -240,11 +240,11 @@ fn admin_state(flags: Option<i64>) -> &'static str {
 }
 
 async fn net_class_devices(sys_path: PathBuf) -> Result<Vec<String>, Error> {
-    let mut dirs = std::fs::read_dir(sys_path.join("class/net"))?;
-    let mut devices = Vec::new();
+    let dirs = std::fs::read_dir(sys_path.join("class/net"))?;
 
-    while let Some(Ok(ent)) = dirs.next() {
-        devices.push(ent.file_name().into_string().unwrap());
+    let mut devices = Vec::new();
+    for entry in dirs.flatten() {
+        devices.push(entry.file_name().into_string().unwrap());
     }
 
     Ok(devices)
@@ -335,10 +335,10 @@ struct NetClassInterface {
 
 impl NetClassInterface {
     pub async fn parse(path: &str) -> Result<NetClassInterface, Error> {
-        let mut dirs = std::fs::read_dir(path)?;
-        let mut nci = NetClassInterface::default();
+        let dirs = std::fs::read_dir(path)?;
 
-        while let Some(Ok(entry)) = dirs.next() {
+        let mut nci = NetClassInterface::default();
+        for entry in dirs.flatten() {
             let file = entry.file_name();
             let value = match read_to_string(entry.path()) {
                 Ok(v) => v,

--- a/src/sources/node/nfs.rs
+++ b/src/sources/node/nfs.rs
@@ -444,7 +444,7 @@ pub async fn gather(proc_path: PathBuf) -> Result<Vec<Metric>, Error> {
     ]);
 
     // collects statistics for NFSv3 requests
-    metrics.extend_from_slice(&[
+    metrics.extend([
         procedure_metric!("3", "Null", stats.v3_stats.null),
         procedure_metric!("3", "GetAttr", stats.v3_stats.get_attr),
         procedure_metric!("3", "SetAttr", stats.v3_stats.set_attr),
@@ -470,7 +470,7 @@ pub async fn gather(proc_path: PathBuf) -> Result<Vec<Metric>, Error> {
     ]);
 
     // collects statistics for NFSv4 requests
-    metrics.extend_from_slice(&[
+    metrics.extend([
         procedure_metric!("4", "Null", stats.client_v4_stats.null),
         procedure_metric!("4", "Read", stats.client_v4_stats.read),
         procedure_metric!("4", "Write", stats.client_v4_stats.write),

--- a/src/sources/node/rapl.rs
+++ b/src/sources/node/rapl.rs
@@ -41,8 +41,8 @@ async fn get_rapl_zones(sys_path: PathBuf) -> Result<Vec<RaplZone>, Error> {
     let mut names: BTreeMap<String, i32> = BTreeMap::new();
 
     // loop through directory files searching for file "name" from subdirs
-    let mut dirs = std::fs::read_dir(root)?;
-    while let Some(Ok(entry)) = dirs.next() {
+    let dirs = std::fs::read_dir(root)?;
+    for entry in dirs.flatten() {
         let path = entry.path().join("name");
         let name = match read_to_string(path) {
             Ok(c) => c,

--- a/src/sources/node/time.rs
+++ b/src/sources/node/time.rs
@@ -88,11 +88,10 @@ struct ClockSource {
 }
 
 fn parse_clock_sources(root: &Path) -> Result<Vec<ClockSource>, Error> {
-    let path = root.join("devices/system/clocksource");
-    let mut dirs = std::fs::read_dir(path)?;
+    let dirs = std::fs::read_dir(root.join("devices/system/clocksource"))?;
 
     let mut sources = vec![];
-    while let Some(Ok(entry)) = dirs.next() {
+    for entry in dirs.flatten() {
         let name = match entry
             .file_name()
             .to_string_lossy()

--- a/src/sources/node/udp_queues.rs
+++ b/src/sources/node/udp_queues.rs
@@ -42,7 +42,7 @@ pub async fn gather(proc_path: PathBuf) -> Result<Vec<Metric>, Error> {
 
     match net_ip_socket_summary(proc_path.join("net/udp6")).await {
         Ok(v6) => {
-            metrics.extend_from_slice(&[
+            metrics.extend([
                 Metric::gauge_with_tags(
                     "node_udp_queues",
                     "Number of allocated memory in the kernel for UDP datagrams in bytes.",

--- a/src/sources/node/watchdog.rs
+++ b/src/sources/node/watchdog.rs
@@ -5,11 +5,10 @@ use event::{tags, Metric};
 use super::{read_into, read_to_string};
 
 pub async fn gather(sys_path: PathBuf) -> Result<Vec<Metric>, crate::Error> {
-    let root = sys_path.join("class/watchdog");
-    let mut dirs = root.read_dir()?;
+    let dirs = sys_path.join("class/watchdog").read_dir()?;
 
     let mut metrics = Vec::new();
-    while let Some(Ok(entry)) = dirs.next() {
+    for entry in dirs.flatten() {
         let path = entry.path();
         let name = entry.file_name().to_string_lossy().to_string();
         let stat = parse_watchdog(path)?;


### PR DESCRIPTION
Now, `read_to_string` is not implement with `std::fs::read_to_string`, which call `metadata` inside, but the metadata returned is 0 or 4096(which is not real size).

And now, memory usage is decrease to ~26MB